### PR TITLE
Add QML interface for LaunchPad dashboard and wizard

### DIFF
--- a/src/gui/qml/GlobalDashboard.qml
+++ b/src/gui/qml/GlobalDashboard.qml
@@ -1,0 +1,315 @@
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+Item {
+    id: root
+    property var theme
+    property var projectsModel
+    property var projectDetails
+    signal backRequested()
+    signal openProject(string projectKey)
+
+    property int totalProjects: 0
+    property int activeProjects: 0
+    property real usageHours: 0
+    property var statusBreakdown: []
+
+    function statusColor(value) {
+        if (!value)
+            return theme.muted
+        var text = value.toLowerCase()
+        if (text.indexOf("run") !== -1 || text.indexOf("ready") !== -1 || text.indexOf("healthy") !== -1)
+            return theme.success
+        if (text.indexOf("fail") !== -1 || text.indexOf("error") !== -1)
+            return theme.danger
+        if (text.indexOf("pause") !== -1 || text.indexOf("stop") !== -1)
+            return theme.warning
+        return theme.accent
+    }
+
+    function refreshMetrics() {
+        if (!projectsModel)
+            return
+        totalProjects = projectsModel.count
+        var active = 0
+        var usage = 0
+        var stats = {}
+        for (var i = 0; i < projectsModel.count; ++i) {
+            var proj = projectsModel.get(i)
+            if (proj.active)
+                active += 1
+            usage += proj.usageHours
+            var status = proj.status || "Unknown"
+            if (!stats[status])
+                stats[status] = 0
+            stats[status] += 1
+        }
+        activeProjects = active
+        usageHours = usage
+        var entries = []
+        for (var key in stats)
+            entries.push({ status: key, count: stats[key] })
+        statusBreakdown = entries
+    }
+
+    function toggleProject(index) {
+        if (!projectsModel)
+            return
+        var proj = projectsModel.get(index)
+        projectsModel.setProperty(index, "active", !proj.active)
+        refreshMetrics()
+    }
+
+    onProjectsModelChanged: refreshMetrics()
+    Component.onCompleted: refreshMetrics()
+
+    Connections {
+        target: projectsModel
+        function onDataChanged() { refreshMetrics() }
+        function onRowsInserted() { refreshMetrics() }
+        function onRowsRemoved() { refreshMetrics() }
+        function onModelReset() { refreshMetrics() }
+        function onCountChanged() { refreshMetrics() }
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 0
+
+        ToolBar {
+            Layout.fillWidth: true
+            padding: 12
+            background: Rectangle { color: Qt.rgba(0, 0, 0, 0) }
+
+            RowLayout {
+                anchors.fill: parent
+                spacing: 12
+
+                ToolButton {
+                    text: "← Back"
+                    onClicked: backRequested()
+                }
+
+                Label {
+                    text: "Global dashboard"
+                    font.pixelSize: 24
+                    font.bold: true
+                    color: theme.textPrimary
+                }
+
+                Item { Layout.fillWidth: true }
+
+                Label {
+                    text: "Active " + activeProjects + " / " + totalProjects
+                    color: theme.textSecondary
+                }
+            }
+        }
+
+        ScrollView {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            clip: true
+
+            ColumnLayout {
+                width: parent.width
+                spacing: 20
+                padding: 24
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: 16
+
+                    Rectangle {
+                        Layout.fillWidth: true
+                        Layout.preferredWidth: 0.33 * parent.width
+                        radius: 12
+                        border.color: theme.border
+                        color: theme.elevated
+                        implicitHeight: 110
+
+                        ColumnLayout {
+                            anchors.fill: parent
+                            anchors.margins: 16
+                            spacing: 8
+
+                            Label { text: "Projects"; color: theme.textSecondary }
+                            Label {
+                                text: totalProjects
+                                font.pixelSize: 32
+                                font.bold: true
+                                color: theme.textPrimary
+                            }
+                        }
+                    }
+
+                    Rectangle {
+                        Layout.fillWidth: true
+                        Layout.preferredWidth: 0.33 * parent.width
+                        radius: 12
+                        border.color: theme.border
+                        color: theme.elevated
+                        implicitHeight: 110
+
+                        ColumnLayout {
+                            anchors.fill: parent
+                            anchors.margins: 16
+                            spacing: 8
+
+                            Label { text: "Active"; color: theme.textSecondary }
+                            Label {
+                                text: activeProjects
+                                font.pixelSize: 32
+                                font.bold: true
+                                color: theme.success
+                            }
+                        }
+                    }
+
+                    Rectangle {
+                        Layout.fillWidth: true
+                        Layout.preferredWidth: 0.33 * parent.width
+                        radius: 12
+                        border.color: theme.border
+                        color: theme.elevated
+                        implicitHeight: 110
+
+                        ColumnLayout {
+                            anchors.fill: parent
+                            anchors.margins: 16
+                            spacing: 8
+
+                            Label { text: "Usage hours"; color: theme.textSecondary }
+                            Label {
+                                text: usageHours.toFixed(1) + " h"
+                                font.pixelSize: 32
+                                font.bold: true
+                                color: theme.textPrimary
+                            }
+                        }
+                    }
+                }
+
+                GroupBox {
+                    title: "Status overview"
+                    Layout.fillWidth: true
+
+                    Flow {
+                        width: parent.width
+                        spacing: 12
+                        Repeater {
+                            model: statusBreakdown
+                            delegate: Rectangle {
+                                radius: 8
+                                border.color: theme.border
+                                color: theme.surfaceVariant
+                                implicitHeight: 40
+                                implicitWidth: statusLabel.implicitWidth + 24
+
+                                Label {
+                                    id: statusLabel
+                                    text: model.status + " · " + model.count
+                                    anchors.centerIn: parent
+                                    color: theme.textSecondary
+                                }
+                            }
+                        }
+                    }
+                }
+
+                GroupBox {
+                    title: "Projects"
+                    Layout.fillWidth: true
+
+                    ColumnLayout {
+                        spacing: 12
+                        Layout.fillWidth: true
+
+                        Repeater {
+                            model: projectsModel
+                            delegate: Rectangle {
+                                radius: 12
+                                border.color: theme.border
+                                color: theme.elevated
+                                Layout.fillWidth: true
+                                implicitHeight: rowLayout.implicitHeight + 24
+
+                                ColumnLayout {
+                                    id: rowLayout
+                                    anchors.fill: parent
+                                    anchors.margins: 16
+                                    spacing: 12
+
+                                    RowLayout {
+                                        Layout.fillWidth: true
+                                        spacing: 12
+
+                                        Label {
+                                            text: model.icon + " " + model.name
+                                            font.pixelSize: 18
+                                            font.bold: true
+                                            color: theme.textPrimary
+                                            MouseArea {
+                                                anchors.fill: parent
+                                                onClicked: root.openProject(model.key)
+                                            }
+                                        }
+
+                                        Label {
+                                            text: "Profile: " + model.lastProfile
+                                            color: theme.textSecondary
+                                        }
+
+                                        Label {
+                                            text: model.status
+                                            color: root.statusColor(model.status)
+                                        }
+
+                                        Item { Layout.fillWidth: true }
+
+                                        Button {
+                                            text: model.active ? "🔴 Stop" : "🟢 Start"
+                                            onClicked: root.toggleProject(index)
+                                        }
+
+                                        Button {
+                                            text: "Open"
+                                            onClicked: root.openProject(model.key)
+                                        }
+                                    }
+
+                                    Flow {
+                                        width: parent.width
+                                        spacing: 6
+                                        Repeater {
+                                            model: model.tags.split(",")
+                                            delegate: Rectangle {
+                                                radius: 6
+                                                color: theme.surfaceVariant
+                                                border.color: theme.border
+                                                implicitHeight: 22
+                                                implicitWidth: tagLabel.implicitWidth + 12
+                                                visible: modelData.trim().length > 0
+
+                                                Label {
+                                                    id: tagLabel
+                                                    text: modelData.trim()
+                                                    anchors.centerIn: parent
+                                                    color: theme.textSecondary
+                                                    font.pixelSize: 11
+                                                }
+                                            }
+                                        }
+                                        visible: model.tags.length > 0
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/gui/qml/HomeScreen.qml
+++ b/src/gui/qml/HomeScreen.qml
@@ -1,0 +1,317 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import "."
+
+Item {
+    id: root
+    property var theme
+    property var projectsModel
+    property var projectDetails
+    property var tagOptions: []
+    signal createProjectRequested()
+    signal openProject(string projectKey)
+    signal showGlobalDashboard()
+    signal toggleTheme()
+
+    property string searchText: ""
+    property bool favoritesOnly: false
+    property string tagFilter: "All Tags"
+    property string statusFilter: "All Statuses"
+
+    readonly property var statusOptions: [
+        "All Statuses",
+        "Ready",
+        "Running",
+        "Needs Attention",
+        "Failed",
+        "Stopped",
+        "Paused"
+    ]
+
+    function matchesSearch(project) {
+        if (!searchText.length)
+            return true
+        var text = searchText.toLowerCase()
+        var haystack = (project.name + " " + project.tags + " " + project.status + " " + project.lastProfile).toLowerCase()
+        return haystack.indexOf(text) !== -1
+    }
+
+    function matchesTag(project) {
+        if (!tagFilter || tagFilter === "All Tags")
+            return true
+        return project.tags.toLowerCase().indexOf(tagFilter.toLowerCase()) !== -1
+    }
+
+    function matchesStatus(project) {
+        if (!statusFilter || statusFilter === "All Statuses")
+            return true
+        return project.status === statusFilter
+    }
+
+    function includeProject(index) {
+        if (!projectsModel || index < 0 || index >= projectsModel.count)
+            return false
+        var project = projectsModel.get(index)
+        if (favoritesOnly && !project.favorite)
+            return false
+        if (!matchesSearch(project))
+            return false
+        if (!matchesTag(project))
+            return false
+        if (!matchesStatus(project))
+            return false
+        return true
+    }
+
+    function countMatches(favoritesFlag) {
+        if (!projectsModel)
+            return 0
+        var total = 0
+        for (var i = 0; i < projectsModel.count; ++i) {
+            var project = projectsModel.get(i)
+            if (favoritesFlag === true && !project.favorite)
+                continue
+            if (favoritesFlag === false && project.favorite)
+                continue
+            if (includeProject(i))
+                total += 1
+        }
+        return total
+    }
+
+    function toggleFavorite(index) {
+        if (!projectsModel)
+            return
+        var project = projectsModel.get(index)
+        projectsModel.setProperty(index, "favorite", !project.favorite)
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        color: Qt.rgba(0, 0, 0, 0)
+
+        RowLayout {
+            anchors.fill: parent
+            spacing: 0
+
+            Rectangle {
+                Layout.preferredWidth: 260
+                Layout.fillHeight: true
+                color: Qt.rgba(theme.surfaceVariant.r, theme.surfaceVariant.g, theme.surfaceVariant.b, 0.4)
+                border.color: theme.border
+                border.width: 1
+
+                Flickable {
+                    anchors.fill: parent
+                    contentWidth: width
+                    contentHeight: sidebarContent.implicitHeight + 32
+                    clip: true
+
+                    ColumnLayout {
+                        id: sidebarContent
+                        width: parent.width
+                        spacing: 18
+                        anchors.margins: 20
+
+                        Label {
+                            text: "Search"
+                            font.bold: true
+                            color: theme.textPrimary
+                        }
+
+                        TextField {
+                            id: searchField
+                            placeholderText: "Find by name, tag, status"
+                            text: searchText
+                            onTextChanged: root.searchText = text
+                        }
+
+                        Label {
+                            text: "Filters"
+                            font.bold: true
+                            color: theme.textPrimary
+                        }
+
+                        CheckBox {
+                            text: "Favorites only"
+                            checked: favoritesOnly
+                            onToggled: favoritesOnly = checked
+                        }
+
+                        ComboBox {
+                            id: tagSelector
+                            model: ["All Tags"].concat(tagOptions)
+                            currentIndex: 0
+                            onActivated: tagFilter = currentText
+                            Layout.fillWidth: true
+                        }
+
+                        ComboBox {
+                            id: statusSelector
+                            model: statusOptions
+                            currentIndex: 0
+                            onActivated: statusFilter = currentText
+                            Layout.fillWidth: true
+                        }
+
+                        Rectangle {
+                            Layout.fillWidth: true
+                            height: 1
+                            color: theme.border
+                            opacity: 0.4
+                        }
+
+                        Label {
+                            text: "Global"
+                            font.bold: true
+                            color: theme.textPrimary
+                        }
+
+                        Button {
+                            text: "🔄 Sync"
+                            Layout.fillWidth: true
+                        }
+
+                        Button {
+                            text: "⚙️ Settings"
+                            Layout.fillWidth: true
+                        }
+
+                        Button {
+                            text: "🗂 Global dashboard"
+                            Layout.fillWidth: true
+                            onClicked: root.showGlobalDashboard()
+                        }
+
+                        Button {
+                            text: "Toggle theme"
+                            Layout.fillWidth: true
+                            onClicked: root.toggleTheme()
+                        }
+                    }
+                }
+            }
+
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                color: Qt.rgba(0, 0, 0, 0)
+
+                ColumnLayout {
+                    anchors.fill: parent
+                    anchors.margins: 24
+                    spacing: 16
+
+                    RowLayout {
+                        Layout.fillWidth: true
+
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 4
+
+                            Label {
+                                text: "Projects"
+                                font.pixelSize: 26
+                                font.bold: true
+                                color: theme.textPrimary
+                            }
+
+                            Label {
+                                text: projectsModel ? projectsModel.count + " configured" : "No projects"
+                                color: theme.textSecondary
+                            }
+                        }
+
+                        ToolButton {
+                            text: "➕ Add project"
+                            onClicked: root.createProjectRequested()
+                        }
+                    }
+
+                    ScrollView {
+                        Layout.fillWidth: true
+                        Layout.fillHeight: true
+                        clip: true
+
+                        Column {
+                            width: parent.width
+                            spacing: 24
+
+                            Column {
+                                spacing: 12
+                                visible: countMatches(true) > 0
+
+                                Label {
+                                    text: "⭐ Favorites"
+                                    font.bold: true
+                                    color: theme.textSecondary
+                                }
+
+                                Flow {
+                                    width: parent.width
+                                    spacing: 16
+                                    Repeater {
+                                        model: projectsModel
+                                        delegate: ProjectCard {
+                                            visible: includeProject(index) && model.favorite
+                                            key: model.key
+                                            iconGlyph: model.icon
+                                            projectName: model.name
+                                            lastProfile: model.lastProfile
+                                            status: model.status
+                                            favorite: model.favorite
+                                            tags: model.tags
+                                            theme: root.theme
+                                            onQuickLaunch: root.openProject(model.key)
+                                            onOpenDetails: root.openProject(model.key)
+                                            onFavoriteToggled: root.toggleFavorite(index)
+                                        }
+                                    }
+                                }
+                            }
+
+                            Column {
+                                spacing: 12
+
+                                Label {
+                                    text: favoritesOnly ? "Favorites" : "All projects"
+                                    font.bold: true
+                                    color: theme.textSecondary
+                                }
+
+                                Flow {
+                                    width: parent.width
+                                    spacing: 16
+                                    Repeater {
+                                        model: projectsModel
+                                        delegate: ProjectCard {
+                                            visible: includeProject(index) && !model.favorite
+                                            key: model.key
+                                            iconGlyph: model.icon
+                                            projectName: model.name
+                                            lastProfile: model.lastProfile
+                                            status: model.status
+                                            favorite: model.favorite
+                                            tags: model.tags
+                                            theme: root.theme
+                                            onQuickLaunch: root.openProject(model.key)
+                                            onOpenDetails: root.openProject(model.key)
+                                            onFavoriteToggled: root.toggleFavorite(index)
+                                        }
+                                    }
+                                }
+
+                                Label {
+                                    text: "No projects match your filters."
+                                    color: theme.textSecondary
+                                    visible: countMatches(true) === 0 && countMatches(false) === 0
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/gui/qml/ProjectCard.qml
+++ b/src/gui/qml/ProjectCard.qml
@@ -1,0 +1,179 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+Rectangle {
+    id: card
+    property string key: ""
+    property string iconGlyph: "🚀"
+    property string projectName: ""
+    property string lastProfile: ""
+    property string status: ""
+    property bool favorite: false
+    property string tags: ""
+    property var theme
+    signal quickLaunch()
+    signal openDetails()
+    signal favoriteToggled()
+
+    radius: 12
+    border.color: theme.border
+    border.width: 1
+    color: theme.elevated
+    implicitWidth: 280
+    implicitHeight: contentLayout.implicitHeight + 32
+
+    ColumnLayout {
+        id: contentLayout
+        anchors.fill: parent
+        anchors.margins: 16
+        spacing: 10
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 8
+
+            Label {
+                text: iconGlyph
+                font.pixelSize: 32
+                Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
+            }
+
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 4
+
+                Label {
+                    text: projectName
+                    font.pixelSize: 18
+                    font.bold: true
+                    wrapMode: Text.WordWrap
+                    color: theme.textPrimary
+                }
+
+                Label {
+                    text: "Profile · " + lastProfile
+                    color: theme.textSecondary
+                    font.pixelSize: 12
+                }
+            }
+
+            ToolButton {
+                text: favorite ? "⭐" : "☆"
+                Accessible.name: favorite ? "Remove from favorites" : "Mark as favorite"
+                onClicked: favoriteToggled()
+            }
+        }
+
+        Rectangle {
+            Layout.fillWidth: true
+            height: 1
+            color: theme.border
+            opacity: 0.35
+        }
+
+        Flow {
+            width: parent.width
+            spacing: 6
+            Repeater {
+                model: tagList
+                delegate: Rectangle {
+                    radius: 6
+                    color: theme.surfaceVariant
+                    border.color: theme.border
+                    border.width: 1
+                    implicitHeight: 22
+                    implicitWidth: tagLabel.implicitWidth + 12
+
+                    Label {
+                        id: tagLabel
+                        text: modelData
+                        anchors.centerIn: parent
+                        font.pixelSize: 11
+                        color: theme.textSecondary
+                    }
+                }
+            }
+            visible: tagList.length > 0
+        }
+
+        Rectangle {
+            radius: 8
+            border.color: colorForStatus(status)
+            color: Qt.rgba(colorForStatus(status).r, colorForStatus(status).g, colorForStatus(status).b, 0.12)
+            Layout.fillWidth: true
+            height: 36
+
+            RowLayout {
+                anchors.fill: parent
+                anchors.margins: 8
+                spacing: 6
+
+                Label {
+                    text: "Status"
+                    color: theme.textSecondary
+                    font.pixelSize: 12
+                }
+
+                Label {
+                    text: status
+                    color: colorForStatus(status)
+                    font.bold: true
+                }
+            }
+        }
+
+        Button {
+            text: "Quick Launch"
+            Layout.fillWidth: true
+            font.bold: true
+            background: Rectangle {
+                radius: 8
+                color: theme.accent
+            }
+            contentItem: Label {
+                text: parent.text
+                color: "white"
+                font: parent.font
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+            }
+            onClicked: quickLaunch()
+        }
+    }
+
+    TapHandler {
+        acceptedButtons: Qt.LeftButton
+        onTapped: card.openDetails()
+    }
+
+    property var tagList: []
+
+    function parseTags(value) {
+        var parts = value ? value.split(",") : []
+        var clean = []
+        for (var i = 0; i < parts.length; ++i) {
+            var tag = parts[i].trim()
+            if (tag.length)
+                clean.push(tag)
+        }
+        return clean
+    }
+
+    function colorForStatus(value) {
+        if (!value)
+            return theme.muted
+        var text = value.toLowerCase()
+        if (text.indexOf("run") !== -1 || text.indexOf("ready") !== -1 || text.indexOf("healthy") !== -1)
+            return theme.success
+        if (text.indexOf("fail") !== -1 || text.indexOf("error") !== -1)
+            return theme.danger
+        if (text.indexOf("pause") !== -1 || text.indexOf("stop") !== -1)
+            return theme.warning
+        return theme.accent
+    }
+
+    onTagsChanged: tagList = parseTags(tags)
+
+    Component.onCompleted: tagList = parseTags(tags)
+}

--- a/src/gui/qml/ProjectDashboard.qml
+++ b/src/gui/qml/ProjectDashboard.qml
@@ -1,0 +1,389 @@
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+Item {
+    id: root
+    property var theme
+    property var projectData
+    signal backRequested()
+
+    property var componentsData: []
+    property var healthData: []
+    property var historyData: []
+    property var linksData: []
+    property var folderData: []
+
+    function statusColor(value) {
+        if (!value)
+            return theme.muted
+        var text = value.toLowerCase()
+        if (text.indexOf("run") !== -1 || text.indexOf("ready") !== -1 || text.indexOf("healthy") !== -1)
+            return theme.success
+        if (text.indexOf("fail") !== -1 || text.indexOf("error") !== -1)
+            return theme.danger
+        if (text.indexOf("pause") !== -1 || text.indexOf("stop") !== -1)
+            return theme.warning
+        return theme.accent
+    }
+
+    function updateLocalData() {
+        componentsData = projectData && projectData.components ? projectData.components : []
+        healthData = projectData && projectData.healthChecks ? projectData.healthChecks : []
+        historyData = projectData && projectData.history ? projectData.history : []
+        linksData = projectData && projectData.quickLinks ? projectData.quickLinks : []
+        folderData = projectData && projectData.folders ? projectData.folders : []
+    }
+
+    onProjectDataChanged: updateLocalData()
+    Component.onCompleted: updateLocalData()
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 0
+
+        ToolBar {
+            Layout.fillWidth: true
+            padding: 12
+            background: Rectangle { color: Qt.rgba(0, 0, 0, 0) }
+
+            RowLayout {
+                anchors.fill: parent
+                spacing: 12
+
+                ToolButton {
+                    text: "← Back"
+                    onClicked: backRequested()
+                }
+
+                Label {
+                    text: (projectData && projectData.icon ? projectData.icon + " " : "") + (projectData && projectData.name ? projectData.name : "Project")
+                    font.pixelSize: 24
+                    font.bold: true
+                    color: theme.textPrimary
+                }
+
+                Label {
+                    text: projectData && projectData.defaultProfile ? "Profile: " + projectData.defaultProfile : ""
+                    color: theme.textSecondary
+                }
+
+                Item { Layout.fillWidth: true }
+
+                Button { text: "Quick launch" }
+                Button { text: "Advanced launch" }
+                Button { text: "Edit" }
+                Button { text: "Delete" }
+                Button { text: "Logs" }
+            }
+        }
+
+        ScrollView {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            clip: true
+
+            ColumnLayout {
+                width: parent.width
+                spacing: 20
+                padding: 24
+
+                GroupBox {
+                    title: "Project overview"
+                    Layout.fillWidth: true
+
+                    ColumnLayout {
+                        spacing: 8
+                        Layout.fillWidth: true
+
+                        Label {
+                            text: projectData && projectData.summary ? projectData.summary : "Configure commands, folders, and health checks for a one-click launch."
+                            wrapMode: Text.Wrap
+                            color: theme.textSecondary
+                        }
+
+                        Flow {
+                            width: parent.width
+                            spacing: 8
+                            Repeater {
+                                model: folderData
+                                delegate: Rectangle {
+                                    radius: 6
+                                    border.color: theme.border
+                                    color: theme.surfaceVariant
+                                    implicitHeight: 28
+                                    implicitWidth: folderLabel.implicitWidth + 20
+
+                                    Label {
+                                        id: folderLabel
+                                        text: model.label + " · " + model.path
+                                        anchors.centerIn: parent
+                                        font.pixelSize: 12
+                                        color: theme.textSecondary
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                GroupBox {
+                    title: "Components"
+                    Layout.fillWidth: true
+
+                    ColumnLayout {
+                        spacing: 16
+                        Layout.fillWidth: true
+
+                        Repeater {
+                            model: componentsData
+                            delegate: Rectangle {
+                                radius: 12
+                                border.color: theme.border
+                                color: theme.elevated
+                                Layout.fillWidth: true
+                                implicitHeight: componentLayout.implicitHeight + 24
+
+                                ColumnLayout {
+                                    id: componentLayout
+                                    anchors.fill: parent
+                                    anchors.margins: 16
+                                    spacing: 12
+
+                                    RowLayout {
+                                        Layout.fillWidth: true
+                                        spacing: 8
+
+                                        Rectangle {
+                                            width: 12
+                                            height: 12
+                                            radius: 6
+                                            color: statusColor(model.status)
+                                        }
+
+                                        Label {
+                                            text: model.name
+                                            font.pixelSize: 18
+                                            font.bold: true
+                                            color: theme.textPrimary
+                                        }
+
+                                        Item { Layout.fillWidth: true }
+
+                                        Label {
+                                            text: model.status
+                                            color: statusColor(model.status)
+                                            font.bold: true
+                                        }
+                                    }
+
+                                    Label {
+                                        text: model.summary
+                                        color: theme.textSecondary
+                                        wrapMode: Text.Wrap
+                                        Layout.fillWidth: true
+                                    }
+
+                                    RowLayout {
+                                        spacing: 8
+
+                                        Button { text: "Start" }
+                                        Button { text: "Stop" }
+                                        Button { text: "Pause" }
+                                        Button { text: "Resume" }
+                                    }
+
+                                    ColumnLayout {
+                                        spacing: 4
+                                        Layout.fillWidth: true
+                                        visible: model.healthChecks && model.healthChecks.length > 0
+
+                                        Label {
+                                            text: "Health checks"
+                                            font.pixelSize: 12
+                                            color: theme.textSecondary
+                                        }
+
+                                        Repeater {
+                                            model: model.healthChecks
+                                            delegate: RowLayout {
+                                                spacing: 6
+                                                Label {
+                                                    text: modelData.label
+                                                    color: theme.textPrimary
+                                                }
+                                                Label {
+                                                    text: modelData.status
+                                                    color: statusColor(modelData.status)
+                                                }
+                                                Label {
+                                                    text: modelData.detail
+                                                    color: theme.textSecondary
+                                                    wrapMode: Text.Wrap
+                                                }
+                                            }
+                                        }
+                                    }
+
+                                    ColumnLayout {
+                                        spacing: 4
+                                        Layout.fillWidth: true
+
+                                        Label {
+                                            text: "Recent logs"
+                                            font.pixelSize: 12
+                                            color: theme.textSecondary
+                                        }
+
+                                        Rectangle {
+                                            radius: 8
+                                            border.color: theme.border
+                                            color: theme.surfaceVariant
+                                            Layout.fillWidth: true
+                                            implicitHeight: logText.implicitHeight + 16
+
+                                            Text {
+                                                id: logText
+                                                text: model.logs ? model.logs.slice(Math.max(0, model.logs.length - 10)).join("
+") : "No logs yet"
+                                                anchors.margins: 8
+                                                anchors.fill: parent
+                                                color: theme.textSecondary
+                                                font.pixelSize: 12
+                                                wrapMode: Text.Wrap
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: 20
+
+                    GroupBox {
+                        title: "Health checks"
+                        Layout.fillWidth: true
+                        Layout.preferredWidth: 0.4 * parent.width
+
+                        ColumnLayout {
+                            spacing: 8
+                            Repeater {
+                                model: healthData
+                                delegate: RowLayout {
+                                    spacing: 8
+                                    Rectangle {
+                                        width: 10
+                                        height: 10
+                                        radius: 5
+                                        color: statusColor(model.status)
+                                    }
+                                    Label {
+                                        text: model.label
+                                        color: theme.textPrimary
+                                    }
+                                    Label {
+                                        text: model.detail
+                                        color: theme.textSecondary
+                                        wrapMode: Text.Wrap
+                                    }
+                                }
+                            }
+                            Label {
+                                text: healthData.length === 0 ? "No health checks configured yet." : ""
+                                visible: healthData.length === 0
+                                color: theme.textSecondary
+                            }
+                        }
+                    }
+
+                    GroupBox {
+                        title: "Quick links"
+                        Layout.fillWidth: true
+                        Layout.preferredWidth: 0.3 * parent.width
+
+                        ColumnLayout {
+                            spacing: 8
+                            Repeater {
+                                model: linksData
+                                delegate: Button {
+                                    text: model.label
+                                    Layout.fillWidth: true
+                                }
+                            }
+                            Label {
+                                text: linksData.length === 0 ? "No links yet." : ""
+                                visible: linksData.length === 0
+                                color: theme.textSecondary
+                            }
+                        }
+                    }
+
+                    GroupBox {
+                        title: "Recent actions"
+                        Layout.fillWidth: true
+                        Layout.preferredWidth: 0.3 * parent.width
+
+                        ColumnLayout {
+                            spacing: 8
+                            Repeater {
+                                model: historyData
+                                delegate: Label {
+                                    text: model.time + " · " + model.description
+                                    color: theme.textSecondary
+                                }
+                            }
+                            Label {
+                                text: historyData.length === 0 ? "No recorded actions yet." : ""
+                                visible: historyData.length === 0
+                                color: theme.textSecondary
+                            }
+                        }
+                    }
+                }
+
+                Rectangle {
+                    radius: 12
+                    border.color: theme.border
+                    color: theme.surfaceVariant
+                    Layout.fillWidth: true
+                    implicitHeight: teardownLayout.implicitHeight + 24
+
+                    ColumnLayout {
+                        id: teardownLayout
+                        anchors.fill: parent
+                        anchors.margins: 16
+                        spacing: 12
+
+                        RowLayout {
+                            Layout.fillWidth: true
+                            spacing: 12
+                            Label {
+                                text: "Recovery"
+                                font.pixelSize: 18
+                                font.bold: true
+                                color: theme.textPrimary
+                            }
+                        }
+
+                        RowLayout {
+                            spacing: 12
+                            Button { text: "Retry failed only" }
+                            Button { text: "View error logs" }
+                        }
+
+                        RowLayout {
+                            spacing: 12
+                            Button { text: "Teardown all" }
+                            Button { text: "Teardown selected" }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/gui/qml/ProjectWizard.qml
+++ b/src/gui/qml/ProjectWizard.qml
@@ -1,0 +1,529 @@
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+Item {
+    id: root
+    property var theme
+    signal cancelRequested()
+    signal completed(var summary)
+
+    property int currentStep: 0
+    property string errorMessage: ""
+
+    property var wizardData: ({
+        name: "",
+        icon: "🚀",
+        tags: "",
+        template: "None",
+        description: "",
+        defaultProfile: "dev"
+    })
+
+    ListModel {
+        id: stepModel
+        ListElement { title: "Basic Details" }
+        ListElement { title: "Paths & Links" }
+        ListElement { title: "Commands" }
+        ListElement { title: "URLs" }
+        ListElement { title: "Profiles" }
+        ListElement { title: "Review" }
+    }
+
+    ListModel {
+        id: pathModel
+        ListElement { label: "IDE"; value: "~/Projects/example"; type: "IDE" }
+        ListElement { label: "Repository"; value: "~/Projects/example"; type: "Folder" }
+    }
+
+    ListModel {
+        id: commandModel
+        ListElement { title: "Backend API"; cwd: "./services/api"; command: "uvicorn app.main:app --reload" }
+        ListElement { title: "Frontend"; cwd: "./dashboard"; command: "npm run dev" }
+    }
+
+    ListModel {
+        id: urlModel
+        ListElement { label: "Swagger"; url: "http://localhost:8000/docs" }
+        ListElement { label: "Frontend"; url: "http://localhost:5173" }
+    }
+
+    ListModel {
+        id: profileModel
+        ListElement { name: "dev"; description: "Local development" }
+        ListElement { name: "staging"; description: "Staging environment" }
+    }
+
+    property int defaultProfileIndex: 0
+
+    function stepCount() { return stepModel.count }
+
+    function addPath() { pathModel.append({ label: "New entry", value: "", type: "Folder" }) }
+    function removePath(index) { if (index >= 0 && index < pathModel.count) pathModel.remove(index) }
+
+    function addCommand() { commandModel.append({ title: "New command", cwd: "", command: "" }) }
+    function duplicateCommand(index) {
+        if (index >= 0 && index < commandModel.count) {
+            var original = commandModel.get(index)
+            commandModel.insert(index + 1, { title: original.title + " (copy)", cwd: original.cwd, command: original.command })
+        }
+    }
+    function removeCommand(index) { if (commandModel.count > 1 && index >= 0 && index < commandModel.count) commandModel.remove(index) }
+
+    function addUrl() { urlModel.append({ label: "New link", url: "http://" }) }
+    function removeUrl(index) { if (index >= 0 && index < urlModel.count) urlModel.remove(index) }
+
+    function addProfile() { profileModel.append({ name: "profile-" + (profileModel.count + 1), description: "" }) }
+    function duplicateProfile(index) {
+        if (index >= 0 && index < profileModel.count) {
+            var original = profileModel.get(index)
+            profileModel.insert(index + 1, { name: original.name + "-copy", description: original.description })
+        }
+    }
+    function removeProfile(index) {
+        if (profileModel.count <= 1) return
+        if (index >= 0 && index < profileModel.count) {
+            profileModel.remove(index)
+            if (defaultProfileIndex >= profileModel.count) defaultProfileIndex = profileModel.count - 1
+        }
+    }
+
+    function setDefaultProfile(index) {
+        if (index < 0 || index >= profileModel.count) return
+        defaultProfileIndex = index
+        wizardData.defaultProfile = profileModel.get(index).name
+    }
+
+    function nextStep() {
+        errorMessage = ""
+        if (currentStep < stepModel.count - 1) currentStep += 1
+    }
+    function previousStep() {
+        if (currentStep > 0) currentStep -= 1
+        else cancelRequested()
+    }
+
+    function slugify(text) {
+        var slug = text.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "")
+        if (!slug.length) slug = "project-" + Math.round(Math.random() * 10000)
+        return slug
+    }
+
+    function collectList(model) {
+        var result = []
+        for (var i = 0; i < model.count; ++i) result.push(model.get(i))
+        return result
+    }
+
+    function finishWizard() {
+        errorMessage = ""
+        if (!wizardData.name || wizardData.name.trim().length === 0) {
+            errorMessage = "Project name is required."
+            currentStep = 0
+            return
+        }
+
+        var tagsArray = []
+        var tags = wizardData.tags.split(",")
+        for (var i = 0; i < tags.length; ++i) {
+            var tag = tags[i].trim()
+            if (tag.length) tagsArray.push(tag)
+        }
+
+        if (profileModel.count === 0) addProfile()
+        if (defaultProfileIndex >= profileModel.count) defaultProfileIndex = 0
+        wizardData.defaultProfile = profileModel.get(defaultProfileIndex).name
+
+        var summary = {
+            key: slugify(wizardData.name),
+            name: wizardData.name,
+            icon: wizardData.icon && wizardData.icon.length ? wizardData.icon : "🚀",
+            tags: tagsArray,
+            template: wizardData.template,
+            description: wizardData.description,
+            defaultProfile: wizardData.defaultProfile,
+            paths: collectList(pathModel),
+            commands: collectList(commandModel),
+            urls: collectList(urlModel),
+            profiles: collectList(profileModel)
+        }
+
+        summary.components = summary.commands.map(function(cmd) {
+            return {
+                name: cmd.title,
+                status: "Pending",
+                summary: cmd.cwd,
+                statusDetail: cmd.command,
+                logs: [],
+                healthChecks: []
+            }
+        })
+        summary.quickLinks = summary.urls.map(function(link) { return { label: link.label, url: link.url } })
+        summary.folders = summary.paths.map(function(path) { return { label: path.label, path: path.value } })
+        summary.history = [{ time: "Now", description: "Project created" }]
+        summary.healthChecks = []
+
+        completed(summary)
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 0
+
+        ToolBar {
+            Layout.fillWidth: true
+            padding: 12
+            background: Rectangle { color: Qt.rgba(0, 0, 0, 0) }
+
+            RowLayout {
+                anchors.fill: parent
+                spacing: 12
+
+                ToolButton {
+                    text: "← Home"
+                    onClicked: cancelRequested()
+                }
+
+                ColumnLayout {
+                    spacing: 2
+                    Label { text: "Create project"; font.pixelSize: 22; font.bold: true; color: theme.textPrimary }
+                    Label { text: stepModel.get(currentStep).title; color: theme.textSecondary }
+                }
+
+                Item { Layout.fillWidth: true }
+                Label { text: (currentStep + 1) + " / " + stepModel.count; color: theme.textSecondary }
+            }
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            spacing: 0
+
+            Rectangle {
+                Layout.preferredWidth: 220
+                Layout.fillHeight: true
+                color: Qt.rgba(theme.surfaceVariant.r, theme.surfaceVariant.g, theme.surfaceVariant.b, 0.35)
+                border.color: theme.border
+                border.width: 1
+
+                ListView {
+                    anchors.fill: parent
+                    model: stepModel
+                    currentIndex: currentStep
+                    interactive: false
+                    delegate: Rectangle {
+                        width: parent.width
+                        height: 50
+                        color: index === currentStep ? theme.elevated : Qt.rgba(0, 0, 0, 0)
+                        border.color: theme.border
+                        border.width: index === currentStep ? 1 : 0
+
+                        RowLayout {
+                            anchors.fill: parent
+                            anchors.margins: 12
+                            spacing: 12
+                            Rectangle {
+                                width: 20; height: 20; radius: 10
+                                color: index <= currentStep ? theme.accent : theme.surfaceVariant
+                                Label { anchors.centerIn: parent; text: index + 1; font.pixelSize: 11; color: index <= currentStep ? "white" : theme.textSecondary }
+                            }
+                            Label { text: model.title; color: theme.textPrimary; font.bold: index === currentStep }
+                        }
+
+                        MouseArea {
+                            anchors.fill: parent
+                            onClicked: root.currentStep = index
+                        }
+                    }
+                }
+            }
+
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                color: Qt.rgba(0, 0, 0, 0)
+
+                StackLayout {
+                    id: stepStack
+                    anchors.fill: parent
+                    currentIndex: currentStep
+
+                    Item {
+                        anchors.fill: parent
+                        ScrollView {
+                            anchors.fill: parent
+                            ColumnLayout {
+                                width: parent.width
+                                spacing: 16
+                                padding: 24
+                                GroupBox {
+                                    title: "Basic information"
+                                    Layout.fillWidth: true
+                                    ColumnLayout {
+                                        spacing: 12
+                                        Layout.fillWidth: true
+                                        FormLayout {
+                                            Layout.fillWidth: true
+                                            Label { text: "Project name" }
+                                            TextField { text: wizardData.name; Layout.fillWidth: true; onTextChanged: wizardData.name = text }
+                                            Label { text: "Icon" }
+                                            TextField { text: wizardData.icon; Layout.fillWidth: true; onTextChanged: wizardData.icon = text }
+                                            Label { text: "Tags" }
+                                            TextField { text: wizardData.tags; Layout.fillWidth: true; placeholderText: "comma,separated"; onTextChanged: wizardData.tags = text }
+                                            Label { text: "Template" }
+                                            ComboBox { model: ["None", "Python FastAPI", "Node + Vite", "Full-stack Docker"]; Layout.fillWidth: true; onActivated: wizardData.template = currentText; Component.onCompleted: currentIndex = 0 }
+                                            Label { text: "Description" }
+                                            TextArea { text: wizardData.description; Layout.fillWidth: true; implicitHeight: 80; wrapMode: TextEdit.Wrap; onTextChanged: wizardData.description = text }
+                                        }
+                                    }
+                                }
+                                Label { text: errorMessage; color: theme.danger; visible: errorMessage.length > 0 }
+                            }
+                        }
+                    }
+
+                    Item {
+                        anchors.fill: parent
+                        ScrollView {
+                            anchors.fill: parent
+                            ColumnLayout {
+                                width: parent.width
+                                spacing: 16
+                                padding: 24
+                                RowLayout {
+                                    Layout.fillWidth: true
+                                    spacing: 12
+                                    Label { text: "Paths & resources"; font.pixelSize: 20; font.bold: true }
+                                    Item { Layout.fillWidth: true }
+                                    Button { text: "➕ Add"; onClicked: addPath() }
+                                }
+                                Repeater {
+                                    model: pathModel
+                                    delegate: GroupBox {
+                                        title: model.label
+                                        Layout.fillWidth: true
+                                        ColumnLayout {
+                                            spacing: 8
+                                            Layout.fillWidth: true
+                                            ComboBox {
+                                                property var kinds: ["IDE", "Folder", "File", "Docker"]
+                                                model: kinds
+                                                Layout.fillWidth: true
+                                                currentIndex: Math.max(0, kinds.indexOf(model.type))
+                                                onActivated: pathModel.setProperty(index, "type", currentText)
+                                            }
+                                            TextField { placeholderText: "Label"; text: model.label; Layout.fillWidth: true; onTextChanged: pathModel.setProperty(index, "label", text) }
+                                            TextField { placeholderText: "Path or executable"; text: model.value; Layout.fillWidth: true; onTextChanged: pathModel.setProperty(index, "value", text) }
+                                            Button { text: "Remove"; onClicked: removePath(index) }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    Item {
+                        anchors.fill: parent
+                        ScrollView {
+                            anchors.fill: parent
+                            ColumnLayout {
+                                width: parent.width
+                                spacing: 16
+                                padding: 24
+                                RowLayout {
+                                    Layout.fillWidth: true
+                                    spacing: 12
+                                    Label { text: "Launch commands"; font.pixelSize: 20; font.bold: true }
+                                    Item { Layout.fillWidth: true }
+                                    Button { text: "➕ Add command"; onClicked: addCommand() }
+                                }
+                                Repeater {
+                                    model: commandModel
+                                    delegate: GroupBox {
+                                        title: model.title
+                                        Layout.fillWidth: true
+                                        ColumnLayout {
+                                            spacing: 8
+                                            Layout.fillWidth: true
+                                            TextField { placeholderText: "Command name"; text: model.title; Layout.fillWidth: true; onTextChanged: commandModel.setProperty(index, "title", text) }
+                                            TextField { placeholderText: "Working directory"; text: model.cwd; Layout.fillWidth: true; onTextChanged: commandModel.setProperty(index, "cwd", text) }
+                                            TextArea { placeholderText: "Command"; text: model.command; Layout.fillWidth: true; implicitHeight: 100; wrapMode: TextEdit.Wrap; onTextChanged: commandModel.setProperty(index, "command", text) }
+                                            RowLayout {
+                                                spacing: 8
+                                                Button { text: "Duplicate"; onClicked: duplicateCommand(index) }
+                                                Button { text: "Remove"; enabled: commandModel.count > 1; onClicked: removeCommand(index) }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    Item {
+                        anchors.fill: parent
+                        ScrollView {
+                            anchors.fill: parent
+                            ColumnLayout {
+                                width: parent.width
+                                spacing: 16
+                                padding: 24
+                                RowLayout {
+                                    Layout.fillWidth: true
+                                    spacing: 12
+                                    Label { text: "Web dashboards & docs"; font.pixelSize: 20; font.bold: true }
+                                    Item { Layout.fillWidth: true }
+                                    Button { text: "➕ Add link"; onClicked: addUrl() }
+                                }
+                                Repeater {
+                                    model: urlModel
+                                    delegate: GroupBox {
+                                        title: model.label
+                                        Layout.fillWidth: true
+                                        ColumnLayout {
+                                            spacing: 8
+                                            Layout.fillWidth: true
+                                            TextField { placeholderText: "Label"; text: model.label; Layout.fillWidth: true; onTextChanged: urlModel.setProperty(index, "label", text) }
+                                            TextField { placeholderText: "URL"; text: model.url; Layout.fillWidth: true; onTextChanged: urlModel.setProperty(index, "url", text) }
+                                            Button { text: "Remove"; onClicked: removeUrl(index) }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    Item {
+                        anchors.fill: parent
+                        ScrollView {
+                            anchors.fill: parent
+                            ColumnLayout {
+                                width: parent.width
+                                spacing: 16
+                                padding: 24
+                                RowLayout {
+                                    Layout.fillWidth: true
+                                    spacing: 12
+                                    Label { text: "Profiles"; font.pixelSize: 20; font.bold: true }
+                                    Item { Layout.fillWidth: true }
+                                    Button { text: "➕ Add profile"; onClicked: addProfile() }
+                                }
+                                Repeater {
+                                    model: profileModel
+                                    delegate: GroupBox {
+                                        title: model.name
+                                        Layout.fillWidth: true
+                                        ColumnLayout {
+                                            spacing: 8
+                                            Layout.fillWidth: true
+                                            RowLayout {
+                                                spacing: 8
+                                                RadioButton {
+                                                    checked: index === defaultProfileIndex
+                                                    text: "Default"
+                                                    onToggled: if (checked) setDefaultProfile(index)
+                                                }
+                                                Button { text: "Duplicate"; onClicked: duplicateProfile(index) }
+                                                Button { text: "Remove"; enabled: profileModel.count > 1; onClicked: removeProfile(index) }
+                                            }
+                                            TextField {
+                                                placeholderText: "Profile name"
+                                                text: model.name
+                                                Layout.fillWidth: true
+                                                onTextChanged: {
+                                                    profileModel.setProperty(index, "name", text)
+                                                    if (index === defaultProfileIndex)
+                                                        wizardData.defaultProfile = text
+                                                }
+                                            }
+                                            TextArea { placeholderText: "Description"; text: model.description; Layout.fillWidth: true; implicitHeight: 80; wrapMode: TextEdit.Wrap; onTextChanged: profileModel.setProperty(index, "description", text) }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    Item {
+                        anchors.fill: parent
+                        ScrollView {
+                            anchors.fill: parent
+                            ColumnLayout {
+                                width: parent.width
+                                spacing: 16
+                                padding: 24
+                                Label { text: "Review"; font.pixelSize: 22; font.bold: true }
+                                GroupBox {
+                                    title: "Summary"
+                                    Layout.fillWidth: true
+                                    ColumnLayout {
+                                        spacing: 6
+                                        Label { text: "Name: " + wizardData.name; color: theme.textPrimary }
+                                        Label { text: "Template: " + wizardData.template; color: theme.textPrimary }
+                                        Label { text: "Default profile: " + wizardData.defaultProfile; color: theme.textPrimary }
+                                        Label { text: "Tags: " + (wizardData.tags.length ? wizardData.tags : "None") }
+                                    }
+                                }
+                                GroupBox {
+                                    title: "Commands"
+                                    Layout.fillWidth: true
+                                    ColumnLayout {
+                                        spacing: 4
+                                        Repeater {
+                                            model: commandModel
+                                            delegate: Label {
+                                                text: "• " + model.title + " — " + model.command
+                                                color: theme.textSecondary
+                                                wrapMode: Text.Wrap
+                                            }
+                                        }
+                                    }
+                                }
+                                GroupBox {
+                                    title: "URLs"
+                                    Layout.fillWidth: true
+                                    ColumnLayout {
+                                        spacing: 4
+                                        Repeater {
+                                            model: urlModel
+                                            delegate: Label { text: model.label + ": " + model.url; color: theme.textSecondary; wrapMode: Text.Wrap }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Rectangle {
+            Layout.fillWidth: true
+            height: 68
+            color: Qt.rgba(theme.surfaceVariant.r, theme.surfaceVariant.g, theme.surfaceVariant.b, 0.4)
+            border.color: theme.border
+
+            RowLayout {
+                anchors.fill: parent
+                anchors.margins: 16
+                spacing: 12
+                Button { text: "Cancel"; onClicked: cancelRequested() }
+                Item { Layout.fillWidth: true }
+                Button { text: "Back"; enabled: currentStep > 0; onClicked: previousStep() }
+                Button {
+                    visible: currentStep < stepModel.count - 1
+                    text: "Next"
+                    onClicked: nextStep()
+                }
+                Button {
+                    visible: currentStep === stepModel.count - 1
+                    text: "Create project"
+                    highlighted: true
+                    onClicked: finishWizard()
+                }
+            }
+        }
+    }
+}

--- a/src/gui/qml/main.qml
+++ b/src/gui/qml/main.qml
@@ -1,16 +1,426 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
+import "."
 
 ApplicationWindow {
     id: window
-    width: 800
-    height: 600
+    width: 1280
+    height: 800
     visible: true
     title: "LaunchPad"
+    property bool darkMode: true
 
-    // A simple text to show that the QML is loaded
-    Text {
-        text: "Hello, LaunchPad!"
-        anchors.centerIn: parent
+    QtObject {
+        id: theme
+        property color background: window.darkMode ? "#0f172a" : "#f8fafc"
+        property color surface: window.darkMode ? "#1e293b" : "#ffffff"
+        property color surfaceVariant: window.darkMode ? "#14213b" : "#e2e8f0"
+        property color elevated: window.darkMode ? "#1b253d" : "#ffffff"
+        property color textPrimary: window.darkMode ? "#f8fafc" : "#0f172a"
+        property color textSecondary: window.darkMode ? "#cbd5f5" : "#475569"
+        property color muted: window.darkMode ? "#94a3b8" : "#64748b"
+        property color border: window.darkMode ? "#24334f" : "#cbd5f5"
+        property color accent: "#6366f1"
+        property color success: "#22c55e"
+        property color warning: "#f97316"
+        property color danger: "#ef4444"
+    }
+
+    color: theme.background
+
+    function statusColor(status) {
+        if (!status)
+            return theme.muted
+        var lowered = status.toLowerCase()
+        if (lowered.indexOf("run") !== -1 || lowered.indexOf("ready") !== -1 || lowered.indexOf("healthy") !== -1)
+            return theme.success
+        if (lowered.indexOf("fail") !== -1 || lowered.indexOf("error") !== -1)
+            return theme.danger
+        if (lowered.indexOf("pause") !== -1 || lowered.indexOf("stop") !== -1)
+            return theme.warning
+        return theme.accent
+    }
+
+    ListModel {
+        id: projectListModel
+        ListElement {
+            key: "nebula"
+            name: "Nebula CRM"
+            icon: "🪐"
+            lastProfile: "dev"
+            tags: "fastapi,postgres,docker"
+            status: "Ready"
+            favorite: true
+            active: true
+            usageHours: 18.5
+        }
+        ListElement {
+            key: "aurora"
+            name: "Aurora Analytics"
+            icon: "📊"
+            lastProfile: "staging"
+            tags: "data,frontend,vite"
+            status: "Running"
+            favorite: false
+            active: true
+            usageHours: 9.2
+        }
+        ListElement {
+            key: "lunar"
+            name: "Lunar Ops"
+            icon: "🌗"
+            lastProfile: "dev"
+            tags: "docker,compose,ops"
+            status: "Needs Attention"
+            favorite: false
+            active: false
+            usageHours: 3.4
+        }
+        ListElement {
+            key: "quasar"
+            name: "Quasar Docs"
+            icon: "📚"
+            lastProfile: "dev"
+            tags: "docs,mdbook"
+            status: "Ready"
+            favorite: true
+            active: false
+            usageHours: 6.8
+        }
+    }
+
+    property var projectDetails: ({
+        "nebula": {
+            key: "nebula",
+            name: "Nebula CRM",
+            icon: "🪐",
+            defaultProfile: "dev",
+            summary: "Customer portal with FastAPI backend and Vue dashboard.",
+            components: [
+                {
+                    name: "FastAPI Service",
+                    status: "Running",
+                    summary: "Uvicorn server with auto-reload",
+                    statusDetail: "HTTP 200 · Port 8000",
+                    logs: [
+                        "[09:40] Boot sequence started",
+                        "[09:40] Loaded environment dev",
+                        "[09:41] Listening on 0.0.0.0:8000"
+                    ],
+                    healthChecks: [
+                        { label: "HTTP", status: "Healthy", detail: "200 OK" },
+                        { label: "Docker", status: "Healthy", detail: "Container healthy" }
+                    ]
+                },
+                {
+                    name: "Worker Queue",
+                    status: "Running",
+                    summary: "Celery worker connected to Redis",
+                    statusDetail: "Processing 3 jobs",
+                    logs: [
+                        "[09:39] Worker online",
+                        "[09:41] Consumed task send_welcome_email"
+                    ],
+                    healthChecks: [
+                        { label: "Redis", status: "Healthy", detail: "Ping 1.2ms" }
+                    ]
+                },
+                {
+                    name: "Frontend Dev Server",
+                    status: "Paused",
+                    summary: "Vite dev server for Vue dashboard",
+                    statusDetail: "Paused by user",
+                    logs: [
+                        "[08:12] npm run dev",
+                        "[08:15] Hot reload triggered"
+                    ],
+                    healthChecks: [
+                        { label: "HTTP", status: "Paused", detail: "Server paused" }
+                    ]
+                }
+            ],
+            quickLinks: [
+                { label: "Swagger Docs", url: "http://localhost:8000/docs" },
+                { label: "Admin Portal", url: "http://localhost:5173" }
+            ],
+            folders: [
+                { label: "Repository", path: "~/Projects/nebula" },
+                { label: "Docker Compose", path: "~/Projects/nebula/ops" }
+            ],
+            history: [
+                { time: "09:42", description: "Launch (dev)" },
+                { time: "09:44", description: "Restart FastAPI" },
+                { time: "09:50", description: "Teardown frontend" }
+            ],
+            healthChecks: [
+                { label: "API endpoint", status: "Healthy", detail: "200 OK" },
+                { label: "Docker compose", status: "Healthy", detail: "All containers healthy" },
+                { label: "Port 8000", status: "Healthy", detail: "Listening" }
+            ]
+        },
+        "aurora": {
+            key: "aurora",
+            name: "Aurora Analytics",
+            icon: "📊",
+            defaultProfile: "staging",
+            summary: "Data pipeline with Node + Vite front-end dashboard.",
+            components: [
+                {
+                    name: "Ingestion Worker",
+                    status: "Running",
+                    summary: "Python ETL job",
+                    statusDetail: "Processing feed alpha",
+                    logs: [
+                        "[08:30] Sync started",
+                        "[08:45] 1234 records processed"
+                    ],
+                    healthChecks: [
+                        { label: "Database", status: "Healthy", detail: "Latency 20ms" }
+                    ]
+                },
+                {
+                    name: "Analytics UI",
+                    status: "Running",
+                    summary: "Vite dev server",
+                    statusDetail: "Listening on 5174",
+                    logs: [
+                        "[08:12] yarn dev",
+                        "[08:20] Hot reload" 
+                    ],
+                    healthChecks: [
+                        { label: "HTTP", status: "Healthy", detail: "200 OK" }
+                    ]
+                }
+            ],
+            quickLinks: [
+                { label: "Vite Dashboard", url: "http://localhost:5174" },
+                { label: "Grafana", url: "http://localhost:3000" }
+            ],
+            folders: [
+                { label: "Repository", path: "~/Projects/aurora" }
+            ],
+            history: [
+                { time: "Yesterday", description: "Deploy staging" }
+            ],
+            healthChecks: [
+                { label: "HTTP 5174", status: "Healthy", detail: "Dashboard ready" },
+                { label: "Queue depth", status: "Healthy", detail: "4 pending" }
+            ]
+        },
+        "lunar": {
+            key: "lunar",
+            name: "Lunar Ops",
+            icon: "🌗",
+            defaultProfile: "dev",
+            summary: "Dockerized ops toolkit with mixed services.",
+            components: [
+                {
+                    name: "API Gateway",
+                    status: "Failed",
+                    summary: "Nginx reverse proxy",
+                    statusDetail: "Container exited",
+                    logs: [
+                        "[07:12] nginx start",
+                        "[07:15] missing certificate"
+                    ],
+                    healthChecks: [
+                        { label: "Docker", status: "Failed", detail: "Exited (1)" }
+                    ]
+                },
+                {
+                    name: "Telemetry",
+                    status: "Stopped",
+                    summary: "Prometheus instance",
+                    statusDetail: "Stopped by user",
+                    logs: [
+                        "[06:50] Shutdown initiated"
+                    ],
+                    healthChecks: [
+                        { label: "Port 9090", status: "Stopped", detail: "Not listening" }
+                    ]
+                }
+            ],
+            quickLinks: [
+                { label: "Operations Wiki", url: "http://confluence.local/lunar" }
+            ],
+            folders: [
+                { label: "Repository", path: "~/Projects/lunar" },
+                { label: "Docker", path: "~/Projects/lunar/docker" }
+            ],
+            history: [
+                { time: "Today", description: "Launch attempt failed" }
+            ],
+            healthChecks: [
+                { label: "Gateway", status: "Failed", detail: "Container exited" },
+                { label: "Prometheus", status: "Stopped", detail: "Inactive" }
+            ]
+        },
+        "quasar": {
+            key: "quasar",
+            name: "Quasar Docs",
+            icon: "📚",
+            defaultProfile: "dev",
+            summary: "Documentation toolchain built with mdBook.",
+            components: [
+                {
+                    name: "mdBook Serve",
+                    status: "Running",
+                    summary: "mdbook serve --open",
+                    statusDetail: "Listening on :3001",
+                    logs: [
+                        "[08:01] Rebuild complete",
+                        "[08:05] Watching files"
+                    ],
+                    healthChecks: [
+                        { label: "HTTP", status: "Healthy", detail: "200 OK" }
+                    ]
+                }
+            ],
+            quickLinks: [
+                { label: "Docs", url: "http://localhost:3001" },
+                { label: "GitHub", url: "https://github.com/org/quasar" }
+            ],
+            folders: [
+                { label: "Repository", path: "~/Projects/quasar" }
+            ],
+            history: [
+                { time: "Today", description: "Launch (dev)" }
+            ],
+            healthChecks: [
+                { label: "HTTP", status: "Healthy", detail: "200 OK" }
+            ]
+        }
+    })
+
+    property var tagOptions: []
+
+    function updateTagOptions() {
+        var seen = {}
+        for (var i = 0; i < projectListModel.count; ++i) {
+            var tags = projectListModel.get(i).tags.split(",")
+            for (var j = 0; j < tags.length; ++j) {
+                var tag = tags[j].trim()
+                if (tag.length)
+                    seen[tag] = true
+            }
+        }
+        var list = []
+        for (var key in seen)
+            list.push(key)
+        list.sort()
+        tagOptions = list
+    }
+
+    Component.onCompleted: updateTagOptions()
+
+    header: ToolBar {
+        padding: 12
+        contentHeight: implicitHeight
+        background: Rectangle {
+            color: Qt.rgba(0, 0, 0, 0)
+        }
+        RowLayout {
+            anchors.fill: parent
+            spacing: 12
+
+            Label {
+                text: "LaunchPad"
+                font.pixelSize: 24
+                font.bold: true
+                color: theme.textPrimary
+                Layout.alignment: Qt.AlignVCenter
+            }
+
+            Label {
+                text: "One-click project command center"
+                color: theme.textSecondary
+                Layout.alignment: Qt.AlignVCenter
+            }
+
+            Item { Layout.fillWidth: true }
+
+            ToolButton {
+                text: window.darkMode ? "☀️ Light" : "🌙 Dark"
+                onClicked: window.darkMode = !window.darkMode
+                padding: 8
+            }
+        }
+    }
+
+    StackView {
+        id: stackView
+        anchors.fill: parent
+        anchors.topMargin: header.height
+        initialItem: homeComponent
+    }
+
+    Component {
+        id: homeComponent
+        HomeScreen {
+            theme: theme
+            projectsModel: projectListModel
+            tagOptions: window.tagOptions
+            projectDetails: window.projectDetails
+            onCreateProjectRequested: stackView.push(wizardComponent)
+            onOpenProject: function(projectKey) {
+                var details = window.projectDetails[projectKey]
+                if (!details)
+                    details = { name: "Unknown", components: [] }
+                stackView.push({ item: projectComponent, properties: { projectData: details } })
+            }
+            onShowGlobalDashboard: stackView.push(globalComponent)
+            onToggleTheme: window.darkMode = !window.darkMode
+        }
+    }
+
+    Component {
+        id: wizardComponent
+        ProjectWizard {
+            theme: theme
+            onCancelRequested: stackView.pop()
+            onCompleted: function(summary) {
+                var slug = summary.key
+                var displayTags = summary.tags.join(", ")
+                projectListModel.append({
+                    key: slug,
+                    name: summary.name,
+                    icon: summary.icon,
+                    lastProfile: summary.defaultProfile,
+                    tags: displayTags,
+                    status: "Ready",
+                    favorite: false,
+                    active: false,
+                    usageHours: 0
+                })
+                window.projectDetails[slug] = summary
+                window.updateTagOptions()
+                stackView.pop()
+            }
+        }
+    }
+
+    Component {
+        id: projectComponent
+        ProjectDashboard {
+            theme: theme
+            onBackRequested: stackView.pop()
+        }
+    }
+
+    Component {
+        id: globalComponent
+        GlobalDashboard {
+            theme: theme
+            projectsModel: projectListModel
+            projectDetails: window.projectDetails
+            onBackRequested: stackView.pop()
+            onOpenProject: function(projectKey) {
+                var details = window.projectDetails[projectKey]
+                if (!details)
+                    details = { name: "Unknown", components: [] }
+                stackView.push({ item: projectComponent, properties: { projectData: details } })
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- implement the main QML window with sample project data, theming, and navigation between home, project, wizard, and global dashboards
- add a home screen with sidebar filters and project cards for quick launch or navigation into a project
- create reusable project card, a six-step project creation wizard, detailed project dashboard, and a global activity dashboard

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68cfaffa2700832d9a8e0d0680dc68e5