### PR TITLE
Implement core project model and SQLite persistence

### DIFF
--- a/src/core/database.py
+++ b/src/core/database.py
@@ -1,1 +1,212 @@
-# Handles database interactions (SQLite).
+"""SQLite-backed persistence layer for LaunchPad projects."""
+from __future__ import annotations
+
+import json
+import sqlite3
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Iterator, List, Optional
+
+from .project import Project
+
+_DEFAULT_DB_NAME = "projects.db"
+
+
+class ProjectDatabase:
+    """Manage persistence for :class:`~launchpad.core.project.Project` objects."""
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        self._path = self._resolve_path(path)
+        self._connection: Optional[sqlite3.Connection] = None
+
+    # ------------------------------------------------------------------
+    # Connection management
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _resolve_path(path: str | Path | None) -> str:
+        if path is None:
+            base = Path.home() / ".launchpad"
+            base.mkdir(parents=True, exist_ok=True)
+            return str(base / _DEFAULT_DB_NAME)
+        if isinstance(path, Path):
+            candidate = path.expanduser()
+        else:
+            candidate = Path(path).expanduser()
+        if str(candidate) != ":memory:":
+            candidate.parent.mkdir(parents=True, exist_ok=True)
+        return str(candidate)
+
+    def connect(self) -> sqlite3.Connection:
+        if self._connection is None:
+            self._connection = sqlite3.connect(self._path)
+            self._connection.row_factory = sqlite3.Row
+            self._apply_pragmas()
+            self._ensure_schema()
+        return self._connection
+
+    def _apply_pragmas(self) -> None:
+        conn = self._connection
+        if conn is None:
+            return
+        conn.execute("PRAGMA foreign_keys = ON")
+
+    def _ensure_schema(self) -> None:
+        conn = self._connection
+        if conn is None:
+            return
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS projects (
+                key TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                icon TEXT,
+                default_profile TEXT,
+                last_profile TEXT,
+                summary TEXT,
+                tags TEXT,
+                status TEXT,
+                favorite INTEGER NOT NULL DEFAULT 0,
+                active INTEGER NOT NULL DEFAULT 0,
+                usage_hours REAL NOT NULL DEFAULT 0,
+                data TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_projects_status
+            ON projects(status)
+            """
+        )
+        conn.commit()
+
+    def close(self) -> None:
+        if self._connection is not None:
+            self._connection.close()
+            self._connection = None
+
+    def __enter__(self) -> "ProjectDatabase":
+        self.connect()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    @contextmanager
+    def transaction(self) -> Iterator[sqlite3.Connection]:
+        conn = self.connect()
+        try:
+            yield conn
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+
+    # ------------------------------------------------------------------
+    # Project CRUD operations
+    # ------------------------------------------------------------------
+    def list_projects(self) -> List[Project]:
+        conn = self.connect()
+        cursor = conn.execute("SELECT data FROM projects ORDER BY name ASC")
+        return [self._row_to_project(row) for row in cursor.fetchall()]
+
+    def get_project(self, key: str) -> Optional[Project]:
+        conn = self.connect()
+        row = conn.execute("SELECT data FROM projects WHERE key = ?", (key,)).fetchone()
+        if row is None:
+            return None
+        return self._row_to_project(row)
+
+    def upsert_project(self, project: Project) -> Project:
+        conn = self.connect()
+        now = datetime.utcnow()
+        existing = self.get_project(project.key)
+        if project.created_at is None:
+            project.created_at = existing.created_at if existing else now
+        project.updated_at = now
+        payload = project.to_dict()
+        data_json = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+        with self.transaction() as txn:
+            txn.execute(
+                """
+                INSERT INTO projects (
+                    key, name, icon, default_profile, last_profile, summary, tags,
+                    status, favorite, active, usage_hours, data, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(key) DO UPDATE SET
+                    name=excluded.name,
+                    icon=excluded.icon,
+                    default_profile=excluded.default_profile,
+                    last_profile=excluded.last_profile,
+                    summary=excluded.summary,
+                    tags=excluded.tags,
+                    status=excluded.status,
+                    favorite=excluded.favorite,
+                    active=excluded.active,
+                    usage_hours=excluded.usage_hours,
+                    data=excluded.data,
+                    updated_at=excluded.updated_at
+                """,
+                (
+                    project.key,
+                    project.name,
+                    project.icon,
+                    project.default_profile,
+                    project.last_profile,
+                    project.summary,
+                    project.tags_as_text,
+                    project.status,
+                    int(project.favorite),
+                    int(project.active),
+                    project.usage_hours,
+                    data_json,
+                    project.created_at.isoformat(),
+                    project.updated_at.isoformat(),
+                ),
+            )
+        return project
+
+    def delete_project(self, key: str) -> bool:
+        conn = self.connect()
+        with self.transaction() as txn:
+            cursor = txn.execute("DELETE FROM projects WHERE key = ?", (key,))
+        return cursor.rowcount > 0
+
+    def set_favorite(self, key: str, is_favorite: bool) -> Optional[Project]:
+        project = self.get_project(key)
+        if not project:
+            return None
+        project.set_favorite(is_favorite)
+        return self.upsert_project(project)
+
+    def update_last_profile(self, key: str, profile: str) -> Optional[Project]:
+        project = self.get_project(key)
+        if not project:
+            return None
+        project.last_profile = profile
+        return self.upsert_project(project)
+
+    def record_history(self, key: str, description: str, timestamp: Optional[str] = None) -> Optional[Project]:
+        project = self.get_project(key)
+        if not project:
+            return None
+        project.add_history(description, timestamp)
+        return self.upsert_project(project)
+
+    def bulk_import(self, projects: Iterable[Project]) -> None:
+        for project in projects:
+            self.upsert_project(project)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _row_to_project(row: sqlite3.Row) -> Project:
+        payload = json.loads(row["data"])
+        return Project.from_dict(payload)
+
+
+__all__ = ["ProjectDatabase"]

--- a/src/core/project.py
+++ b/src/core/project.py
@@ -1,1 +1,329 @@
-# Contains the data model for a project.
+"""Data model definitions for LaunchPad projects."""
+from __future__ import annotations
+
+from collections.abc import Iterable as IterableABC, Mapping as MappingABC
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, List, Mapping, Optional
+
+
+def _normalize_sequence(value: Any) -> List[Any]:
+    """Return *value* as a plain list.
+
+    The QML layer historically worked with a mixture of comma separated strings
+    and JSON arrays.  To keep backwards compatibility the helper accepts strings
+    (splitting on commas) as well as arbitrary iterables.  ``None`` values are
+    converted into an empty list.
+    """
+
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [item.strip() for item in value.split(",") if item.strip()]
+    if isinstance(value, MappingABC):
+        return [value]
+    if isinstance(value, IterableABC):
+        return [item for item in value]
+    return [value]
+
+
+@dataclass
+class HealthCheck:
+    """Status information about a component or project."""
+
+    label: str
+    status: str
+    detail: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "label": self.label,
+            "status": self.status,
+            "detail": self.detail,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "HealthCheck":
+        return cls(
+            label=str(payload.get("label", "")),
+            status=str(payload.get("status", "")),
+            detail=str(payload.get("detail", "")),
+        )
+
+
+@dataclass
+class QuickLink:
+    """Represents a quick access link for a project."""
+
+    label: str
+    url: str
+
+    def to_dict(self) -> Dict[str, str]:
+        return {"label": self.label, "url": self.url}
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "QuickLink":
+        return cls(
+            label=str(payload.get("label", "")),
+            url=str(payload.get("url", "")),
+        )
+
+
+@dataclass
+class FolderLink:
+    """Represents a folder shortcut displayed in the UI."""
+
+    label: str
+    path: str
+
+    def to_dict(self) -> Dict[str, str]:
+        return {"label": self.label, "path": self.path}
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "FolderLink":
+        return cls(
+            label=str(payload.get("label", "")),
+            path=str(payload.get("path", "")),
+        )
+
+
+@dataclass
+class HistoryEvent:
+    """Represents a single entry in the project activity log."""
+
+    time: str
+    description: str
+
+    def to_dict(self) -> Dict[str, str]:
+        return {"time": self.time, "description": self.description}
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "HistoryEvent":
+        return cls(
+            time=str(payload.get("time", "")),
+            description=str(payload.get("description", "")),
+        )
+
+
+@dataclass
+class Component:
+    """Represents one component in a LaunchPad project."""
+
+    name: str
+    status: str
+    summary: str = ""
+    status_detail: str = ""
+    logs: List[str] = field(default_factory=list)
+    health_checks: List[HealthCheck] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "status": self.status,
+            "summary": self.summary,
+            "statusDetail": self.status_detail,
+            "logs": list(self.logs),
+            "healthChecks": [check.to_dict() for check in self.health_checks],
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "Component":
+        logs = _normalize_sequence(payload.get("logs"))
+        health_data = payload.get("healthChecks", [])
+        health_checks = [
+            HealthCheck.from_dict(item)
+            for item in _normalize_sequence(health_data)
+            if isinstance(item, MappingABC)
+        ]
+        return cls(
+            name=str(payload.get("name", "")),
+            status=str(payload.get("status", "")),
+            summary=str(payload.get("summary", "")),
+            status_detail=str(payload.get("statusDetail", payload.get("status_detail", ""))),
+            logs=[str(item) for item in logs],
+            health_checks=health_checks,
+        )
+
+
+@dataclass
+class Project:
+    """Data class describing a LaunchPad project and its metadata."""
+
+    key: str
+    name: str
+    icon: str = "📁"
+    default_profile: str = "dev"
+    summary: str = ""
+    tags: List[str] = field(default_factory=list)
+    status: str = "Ready"
+    favorite: bool = False
+    active: bool = False
+    last_profile: Optional[str] = None
+    usage_hours: float = 0.0
+    components: List[Component] = field(default_factory=list)
+    quick_links: List[QuickLink] = field(default_factory=list)
+    folders: List[FolderLink] = field(default_factory=list)
+    history: List[HistoryEvent] = field(default_factory=list)
+    health_checks: List[HealthCheck] = field(default_factory=list)
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+    def __post_init__(self) -> None:
+        if self.last_profile is None:
+            self.last_profile = self.default_profile
+        self.tags = [tag for tag in _normalize_sequence(self.tags)]
+        self.usage_hours = float(self.usage_hours)
+
+    # ------------------------------------------------------------------
+    # Serialization helpers
+    # ------------------------------------------------------------------
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert the project into a JSON serialisable dictionary."""
+
+        payload: Dict[str, Any] = {
+            "key": self.key,
+            "name": self.name,
+            "icon": self.icon,
+            "defaultProfile": self.default_profile,
+            "lastProfile": self.last_profile,
+            "summary": self.summary,
+            "tags": list(self.tags),
+            "status": self.status,
+            "favorite": self.favorite,
+            "active": self.active,
+            "usageHours": self.usage_hours,
+            "components": [component.to_dict() for component in self.components],
+            "quickLinks": [link.to_dict() for link in self.quick_links],
+            "folders": [folder.to_dict() for folder in self.folders],
+            "history": [event.to_dict() for event in self.history],
+            "healthChecks": [check.to_dict() for check in self.health_checks],
+        }
+        if self.created_at is not None:
+            payload["createdAt"] = self.created_at.isoformat()
+        if self.updated_at is not None:
+            payload["updatedAt"] = self.updated_at.isoformat()
+        return payload
+
+    def to_overview(self) -> Dict[str, Any]:
+        """Return only the fields required for the home screen grid."""
+
+        return {
+            "key": self.key,
+            "name": self.name,
+            "icon": self.icon,
+            "lastProfile": self.last_profile,
+            "tags": ", ".join(self.tags),
+            "status": self.status,
+            "favorite": self.favorite,
+            "active": self.active,
+            "usageHours": self.usage_hours,
+        }
+
+    @property
+    def tags_as_text(self) -> str:
+        """Return the project tags as a comma separated string."""
+
+        return ", ".join(self.tags)
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "Project":
+        """Create a project instance from a mapping."""
+
+        tags = payload.get("tags", [])
+        components_raw = payload.get("components", [])
+        quick_links_raw = payload.get("quickLinks", [])
+        folders_raw = payload.get("folders", [])
+        history_raw = payload.get("history", [])
+        health_checks_raw = payload.get("healthChecks", [])
+
+        created_at = payload.get("createdAt")
+        updated_at = payload.get("updatedAt")
+
+        return cls(
+            key=str(payload.get("key", "")),
+            name=str(payload.get("name", "")),
+            icon=str(payload.get("icon", "📁")),
+            default_profile=str(payload.get("defaultProfile", payload.get("default_profile", "dev"))),
+            last_profile=payload.get("lastProfile", payload.get("last_profile")),
+            summary=str(payload.get("summary", "")),
+            tags=_normalize_sequence(tags),
+            status=str(payload.get("status", "Ready")),
+            favorite=bool(payload.get("favorite", False)),
+            active=bool(payload.get("active", False)),
+            usage_hours=float(payload.get("usageHours", payload.get("usage_hours", 0.0))),
+            components=[
+                component
+                if isinstance(component, Component)
+                else Component.from_dict(component)
+                for component in components_raw
+                if isinstance(component, (MappingABC, Component))
+            ],
+            quick_links=[
+                link
+                if isinstance(link, QuickLink)
+                else QuickLink.from_dict(link)
+                for link in quick_links_raw
+                if isinstance(link, (MappingABC, QuickLink))
+            ],
+            folders=[
+                folder
+                if isinstance(folder, FolderLink)
+                else FolderLink.from_dict(folder)
+                for folder in folders_raw
+                if isinstance(folder, (MappingABC, FolderLink))
+            ],
+            history=[
+                event
+                if isinstance(event, HistoryEvent)
+                else HistoryEvent.from_dict(event)
+                for event in history_raw
+                if isinstance(event, (MappingABC, HistoryEvent))
+            ],
+            health_checks=[
+                check
+                if isinstance(check, HealthCheck)
+                else HealthCheck.from_dict(check)
+                for check in health_checks_raw
+                if isinstance(check, (MappingABC, HealthCheck))
+            ],
+            created_at=datetime.fromisoformat(created_at) if created_at else None,
+            updated_at=datetime.fromisoformat(updated_at) if updated_at else None,
+        )
+
+    # ------------------------------------------------------------------
+    # Domain helpers
+    # ------------------------------------------------------------------
+    def add_history(self, description: str, timestamp: Optional[str] = None) -> None:
+        """Append a new history entry."""
+
+        if timestamp is None:
+            timestamp = datetime.now().strftime("%H:%M")
+        self.history.append(HistoryEvent(time=timestamp, description=description))
+
+    def set_favorite(self, is_favorite: bool) -> None:
+        self.favorite = bool(is_favorite)
+
+    def touch(self) -> None:
+        """Update the ``updated_at`` timestamp to *now*."""
+
+        self.updated_at = datetime.utcnow()
+
+    def ensure_component(self, component: Component) -> None:
+        """Add or replace a component with the same name."""
+
+        for index, existing in enumerate(self.components):
+            if existing.name == component.name:
+                self.components[index] = component
+                break
+        else:
+            self.components.append(component)
+
+
+__all__ = [
+    "HealthCheck",
+    "QuickLink",
+    "FolderLink",
+    "HistoryEvent",
+    "Component",
+    "Project",
+]


### PR DESCRIPTION
## Summary
- add comprehensive dataclasses to represent projects, components, history, and related metadata
- implement a SQLite-backed ProjectDatabase with CRUD helpers and JSON serialization to bridge the UI and persistence layers

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68cfb497cd7c832d80f48dd2975e2243