### PR TITLE
Expose database-backed projects to QML

### DIFF
--- a/src/gui/__init__.py
+++ b/src/gui/__init__.py
@@ -1,0 +1,5 @@
+"""GUI helpers for the LaunchPad application."""
+
+from .project_list_model import ProjectListModel
+
+__all__ = ["ProjectListModel"]

--- a/src/gui/project_list_model.py
+++ b/src/gui/project_list_model.py
@@ -1,0 +1,234 @@
+"""Qt list model exposing :class:`~core.project.Project` instances to QML."""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from PySide6.QtCore import QAbstractListModel, QModelIndex, QObject, Qt, Slot
+
+from core.database import ProjectDatabase
+from core.project import Project
+
+
+class ProjectListModel(QAbstractListModel):
+    """Expose project overview information to Qt's model/view layer."""
+
+    KeyRole = Qt.UserRole + 1
+    NameRole = Qt.UserRole + 2
+    IconRole = Qt.UserRole + 3
+    LastProfileRole = Qt.UserRole + 4
+    TagsRole = Qt.UserRole + 5
+    StatusRole = Qt.UserRole + 6
+    FavoriteRole = Qt.UserRole + 7
+    ActiveRole = Qt.UserRole + 8
+    UsageHoursRole = Qt.UserRole + 9
+
+    _ROLE_NAMES = {
+        KeyRole: b"key",
+        NameRole: b"name",
+        IconRole: b"icon",
+        LastProfileRole: b"lastProfile",
+        TagsRole: b"tags",
+        StatusRole: b"status",
+        FavoriteRole: b"favorite",
+        ActiveRole: b"active",
+        UsageHoursRole: b"usageHours",
+    }
+
+    def __init__(self, database: ProjectDatabase, parent: Optional[QObject] = None) -> None:
+        super().__init__(parent)
+        self._database = database
+        self._projects: List[Project] = []
+        self.refresh()
+
+    # ------------------------------------------------------------------
+    # Qt model API
+    # ------------------------------------------------------------------
+    def rowCount(self, parent: QModelIndex = QModelIndex()) -> int:  # type: ignore[override]
+        if parent.isValid():
+            return 0
+        return len(self._projects)
+
+    def data(self, index: QModelIndex, role: int = Qt.DisplayRole) -> Any:  # type: ignore[override]
+        if not index.isValid():
+            return None
+        row = index.row()
+        if row < 0 or row >= len(self._projects):
+            return None
+        project = self._projects[row]
+        if role in (Qt.DisplayRole, ProjectListModel.NameRole):
+            return project.name
+        if role == ProjectListModel.KeyRole:
+            return project.key
+        if role == ProjectListModel.IconRole:
+            return project.icon
+        if role == ProjectListModel.LastProfileRole:
+            return project.last_profile
+        if role == ProjectListModel.TagsRole:
+            return ", ".join(project.tags)
+        if role == ProjectListModel.StatusRole:
+            return project.status
+        if role == ProjectListModel.FavoriteRole:
+            return project.favorite
+        if role == ProjectListModel.ActiveRole:
+            return project.active
+        if role == ProjectListModel.UsageHoursRole:
+            return project.usage_hours
+        return None
+
+    def roleNames(self) -> Dict[int, bytes]:  # type: ignore[override]
+        return dict(ProjectListModel._ROLE_NAMES)
+
+    def flags(self, index: QModelIndex) -> Qt.ItemFlags:  # type: ignore[override]
+        base_flags = super().flags(index)
+        if not index.isValid():
+            return base_flags
+        return base_flags | Qt.ItemIsEditable
+
+    def setData(self, index: QModelIndex, value: Any, role: int = Qt.EditRole) -> bool:  # type: ignore[override]
+        if not index.isValid():
+            return False
+        row = index.row()
+        if row < 0 or row >= len(self._projects):
+            return False
+
+        project = self._projects[row]
+        changed = False
+
+        if role == ProjectListModel.KeyRole:
+            new_value = str(value)
+            if new_value and new_value != project.key:
+                project.key = new_value
+                changed = True
+        elif role == ProjectListModel.NameRole:
+            new_value = str(value)
+            if new_value != project.name:
+                project.name = new_value
+                changed = True
+        elif role == ProjectListModel.IconRole:
+            new_value = str(value)
+            if new_value != project.icon:
+                project.icon = new_value
+                changed = True
+        elif role == ProjectListModel.LastProfileRole:
+            new_value = str(value)
+            if new_value != project.last_profile:
+                project.last_profile = new_value
+                changed = True
+        elif role == ProjectListModel.TagsRole:
+            text = str(value)
+            tags = [item.strip() for item in text.split(",") if item.strip()]
+            if tags != project.tags:
+                project.tags = tags
+                changed = True
+        elif role == ProjectListModel.StatusRole:
+            new_value = str(value)
+            if new_value != project.status:
+                project.status = new_value
+                changed = True
+        elif role == ProjectListModel.FavoriteRole:
+            new_value = bool(value)
+            if new_value != project.favorite:
+                project.favorite = new_value
+                changed = True
+        elif role == ProjectListModel.ActiveRole:
+            new_value = bool(value)
+            if new_value != project.active:
+                project.active = new_value
+                changed = True
+        elif role == ProjectListModel.UsageHoursRole:
+            try:
+                new_value = float(value)
+            except (TypeError, ValueError):
+                new_value = project.usage_hours
+            if new_value != project.usage_hours:
+                project.usage_hours = new_value
+                changed = True
+        else:
+            # Unsupported role
+            return False
+
+        if not changed:
+            return False
+
+        self._database.upsert_project(project)
+        self.dataChanged.emit(index, index, [role])
+        return True
+
+    # ------------------------------------------------------------------
+    # Data management helpers
+    # ------------------------------------------------------------------
+    def refresh(self) -> None:
+        self.beginResetModel()
+        self._projects = self._database.list_projects()
+        self.endResetModel()
+
+    def _project_overview(self, project: Project) -> Dict[str, Any]:
+        return {
+            "key": project.key,
+            "name": project.name,
+            "icon": project.icon,
+            "lastProfile": project.last_profile,
+            "tags": ", ".join(project.tags),
+            "status": project.status,
+            "favorite": project.favorite,
+            "active": project.active,
+            "usageHours": project.usage_hours,
+        }
+
+    def _project_by_key(self, key: str) -> Optional[Project]:
+        for project in self._projects:
+            if project.key == key:
+                return project
+        return None
+
+    # ------------------------------------------------------------------
+    # Invokable helpers for QML
+    # ------------------------------------------------------------------
+    @Slot(int, result="QVariant")
+    def get(self, row: int) -> Dict[str, Any]:
+        if 0 <= row < len(self._projects):
+            return self._project_overview(self._projects[row])
+        return {}
+
+    @Slot(str, result="QVariant")
+    def getProject(self, key: str) -> Dict[str, Any]:
+        if not key:
+            return {}
+        project = self._project_by_key(key)
+        if project is None:
+            project = self._database.get_project(key)
+        if project is None:
+            return {}
+        return project.to_dict()
+
+    @Slot("QVariant", result=bool)
+    def addProject(self, payload: Any) -> bool:
+        if payload is None:
+            return False
+        if isinstance(payload, dict):
+            data = dict(payload)
+        else:
+            try:
+                data = dict(payload)
+            except TypeError:
+                return False
+
+        description = data.get("description")
+        if description and not data.get("summary"):
+            data["summary"] = str(description)
+
+        try:
+            project = Project.from_dict(data)
+        except Exception:
+            return False
+
+        self._database.upsert_project(project)
+        self.refresh()
+        return True
+
+    @Slot()
+    def reload(self) -> None:
+        self.refresh()
+
+
+__all__ = ["ProjectListModel"]

--- a/src/gui/qml/GlobalDashboard.qml
+++ b/src/gui/qml/GlobalDashboard.qml
@@ -7,7 +7,6 @@ Item {
     id: root
     property var theme
     property var projectsModel
-    property var projectDetails
     signal backRequested()
     signal openProject(string projectKey)
 

--- a/src/gui/qml/HomeScreen.qml
+++ b/src/gui/qml/HomeScreen.qml
@@ -7,7 +7,6 @@ Item {
     id: root
     property var theme
     property var projectsModel
-    property var projectDetails
     property var tagOptions: []
     signal createProjectRequested()
     signal openProject(string projectKey)

--- a/src/gui/qml/main.qml
+++ b/src/gui/qml/main.qml
@@ -42,263 +42,17 @@ ApplicationWindow {
         return theme.accent
     }
 
-    ListModel {
-        id: projectListModel
-        ListElement {
-            key: "nebula"
-            name: "Nebula CRM"
-            icon: "🪐"
-            lastProfile: "dev"
-            tags: "fastapi,postgres,docker"
-            status: "Ready"
-            favorite: true
-            active: true
-            usageHours: 18.5
-        }
-        ListElement {
-            key: "aurora"
-            name: "Aurora Analytics"
-            icon: "📊"
-            lastProfile: "staging"
-            tags: "data,frontend,vite"
-            status: "Running"
-            favorite: false
-            active: true
-            usageHours: 9.2
-        }
-        ListElement {
-            key: "lunar"
-            name: "Lunar Ops"
-            icon: "🌗"
-            lastProfile: "dev"
-            tags: "docker,compose,ops"
-            status: "Needs Attention"
-            favorite: false
-            active: false
-            usageHours: 3.4
-        }
-        ListElement {
-            key: "quasar"
-            name: "Quasar Docs"
-            icon: "📚"
-            lastProfile: "dev"
-            tags: "docs,mdbook"
-            status: "Ready"
-            favorite: true
-            active: false
-            usageHours: 6.8
-        }
-    }
-
-    property var projectDetails: ({
-        "nebula": {
-            key: "nebula",
-            name: "Nebula CRM",
-            icon: "🪐",
-            defaultProfile: "dev",
-            summary: "Customer portal with FastAPI backend and Vue dashboard.",
-            components: [
-                {
-                    name: "FastAPI Service",
-                    status: "Running",
-                    summary: "Uvicorn server with auto-reload",
-                    statusDetail: "HTTP 200 · Port 8000",
-                    logs: [
-                        "[09:40] Boot sequence started",
-                        "[09:40] Loaded environment dev",
-                        "[09:41] Listening on 0.0.0.0:8000"
-                    ],
-                    healthChecks: [
-                        { label: "HTTP", status: "Healthy", detail: "200 OK" },
-                        { label: "Docker", status: "Healthy", detail: "Container healthy" }
-                    ]
-                },
-                {
-                    name: "Worker Queue",
-                    status: "Running",
-                    summary: "Celery worker connected to Redis",
-                    statusDetail: "Processing 3 jobs",
-                    logs: [
-                        "[09:39] Worker online",
-                        "[09:41] Consumed task send_welcome_email"
-                    ],
-                    healthChecks: [
-                        { label: "Redis", status: "Healthy", detail: "Ping 1.2ms" }
-                    ]
-                },
-                {
-                    name: "Frontend Dev Server",
-                    status: "Paused",
-                    summary: "Vite dev server for Vue dashboard",
-                    statusDetail: "Paused by user",
-                    logs: [
-                        "[08:12] npm run dev",
-                        "[08:15] Hot reload triggered"
-                    ],
-                    healthChecks: [
-                        { label: "HTTP", status: "Paused", detail: "Server paused" }
-                    ]
-                }
-            ],
-            quickLinks: [
-                { label: "Swagger Docs", url: "http://localhost:8000/docs" },
-                { label: "Admin Portal", url: "http://localhost:5173" }
-            ],
-            folders: [
-                { label: "Repository", path: "~/Projects/nebula" },
-                { label: "Docker Compose", path: "~/Projects/nebula/ops" }
-            ],
-            history: [
-                { time: "09:42", description: "Launch (dev)" },
-                { time: "09:44", description: "Restart FastAPI" },
-                { time: "09:50", description: "Teardown frontend" }
-            ],
-            healthChecks: [
-                { label: "API endpoint", status: "Healthy", detail: "200 OK" },
-                { label: "Docker compose", status: "Healthy", detail: "All containers healthy" },
-                { label: "Port 8000", status: "Healthy", detail: "Listening" }
-            ]
-        },
-        "aurora": {
-            key: "aurora",
-            name: "Aurora Analytics",
-            icon: "📊",
-            defaultProfile: "staging",
-            summary: "Data pipeline with Node + Vite front-end dashboard.",
-            components: [
-                {
-                    name: "Ingestion Worker",
-                    status: "Running",
-                    summary: "Python ETL job",
-                    statusDetail: "Processing feed alpha",
-                    logs: [
-                        "[08:30] Sync started",
-                        "[08:45] 1234 records processed"
-                    ],
-                    healthChecks: [
-                        { label: "Database", status: "Healthy", detail: "Latency 20ms" }
-                    ]
-                },
-                {
-                    name: "Analytics UI",
-                    status: "Running",
-                    summary: "Vite dev server",
-                    statusDetail: "Listening on 5174",
-                    logs: [
-                        "[08:12] yarn dev",
-                        "[08:20] Hot reload" 
-                    ],
-                    healthChecks: [
-                        { label: "HTTP", status: "Healthy", detail: "200 OK" }
-                    ]
-                }
-            ],
-            quickLinks: [
-                { label: "Vite Dashboard", url: "http://localhost:5174" },
-                { label: "Grafana", url: "http://localhost:3000" }
-            ],
-            folders: [
-                { label: "Repository", path: "~/Projects/aurora" }
-            ],
-            history: [
-                { time: "Yesterday", description: "Deploy staging" }
-            ],
-            healthChecks: [
-                { label: "HTTP 5174", status: "Healthy", detail: "Dashboard ready" },
-                { label: "Queue depth", status: "Healthy", detail: "4 pending" }
-            ]
-        },
-        "lunar": {
-            key: "lunar",
-            name: "Lunar Ops",
-            icon: "🌗",
-            defaultProfile: "dev",
-            summary: "Dockerized ops toolkit with mixed services.",
-            components: [
-                {
-                    name: "API Gateway",
-                    status: "Failed",
-                    summary: "Nginx reverse proxy",
-                    statusDetail: "Container exited",
-                    logs: [
-                        "[07:12] nginx start",
-                        "[07:15] missing certificate"
-                    ],
-                    healthChecks: [
-                        { label: "Docker", status: "Failed", detail: "Exited (1)" }
-                    ]
-                },
-                {
-                    name: "Telemetry",
-                    status: "Stopped",
-                    summary: "Prometheus instance",
-                    statusDetail: "Stopped by user",
-                    logs: [
-                        "[06:50] Shutdown initiated"
-                    ],
-                    healthChecks: [
-                        { label: "Port 9090", status: "Stopped", detail: "Not listening" }
-                    ]
-                }
-            ],
-            quickLinks: [
-                { label: "Operations Wiki", url: "http://confluence.local/lunar" }
-            ],
-            folders: [
-                { label: "Repository", path: "~/Projects/lunar" },
-                { label: "Docker", path: "~/Projects/lunar/docker" }
-            ],
-            history: [
-                { time: "Today", description: "Launch attempt failed" }
-            ],
-            healthChecks: [
-                { label: "Gateway", status: "Failed", detail: "Container exited" },
-                { label: "Prometheus", status: "Stopped", detail: "Inactive" }
-            ]
-        },
-        "quasar": {
-            key: "quasar",
-            name: "Quasar Docs",
-            icon: "📚",
-            defaultProfile: "dev",
-            summary: "Documentation toolchain built with mdBook.",
-            components: [
-                {
-                    name: "mdBook Serve",
-                    status: "Running",
-                    summary: "mdbook serve --open",
-                    statusDetail: "Listening on :3001",
-                    logs: [
-                        "[08:01] Rebuild complete",
-                        "[08:05] Watching files"
-                    ],
-                    healthChecks: [
-                        { label: "HTTP", status: "Healthy", detail: "200 OK" }
-                    ]
-                }
-            ],
-            quickLinks: [
-                { label: "Docs", url: "http://localhost:3001" },
-                { label: "GitHub", url: "https://github.com/org/quasar" }
-            ],
-            folders: [
-                { label: "Repository", path: "~/Projects/quasar" }
-            ],
-            history: [
-                { time: "Today", description: "Launch (dev)" }
-            ],
-            healthChecks: [
-                { label: "HTTP", status: "Healthy", detail: "200 OK" }
-            ]
-        }
-    })
-
     property var tagOptions: []
 
     function updateTagOptions() {
+        if (!projectModel)
+            return
         var seen = {}
-        for (var i = 0; i < projectListModel.count; ++i) {
-            var tags = projectListModel.get(i).tags.split(",")
+        for (var i = 0; i < projectModel.count; ++i) {
+            var project = projectModel.get(i)
+            if (!project || !project.tags)
+                continue
+            var tags = project.tags.split(',')
             for (var j = 0; j < tags.length; ++j) {
                 var tag = tags[j].trim()
                 if (tag.length)
@@ -310,6 +64,14 @@ ApplicationWindow {
             list.push(key)
         list.sort()
         tagOptions = list
+    }
+
+    Connections {
+        target: projectModel
+        function onDataChanged() { window.updateTagOptions() }
+        function onModelReset() { window.updateTagOptions() }
+        function onRowsInserted() { window.updateTagOptions() }
+        function onRowsRemoved() { window.updateTagOptions() }
     }
 
     Component.onCompleted: updateTagOptions()
@@ -359,14 +121,13 @@ ApplicationWindow {
         id: homeComponent
         HomeScreen {
             theme: theme
-            projectsModel: projectListModel
+            projectsModel: projectModel
             tagOptions: window.tagOptions
-            projectDetails: window.projectDetails
             onCreateProjectRequested: stackView.push(wizardComponent)
             onOpenProject: function(projectKey) {
-                var details = window.projectDetails[projectKey]
-                if (!details)
-                    details = { name: "Unknown", components: [] }
+                var details = projectModel.getProject(projectKey)
+                if (!details || !details.key)
+                    details = { key: projectKey, name: "Unknown", components: [] }
                 stackView.push({ item: projectComponent, properties: { projectData: details } })
             }
             onShowGlobalDashboard: stackView.push(globalComponent)
@@ -380,22 +141,12 @@ ApplicationWindow {
             theme: theme
             onCancelRequested: stackView.pop()
             onCompleted: function(summary) {
-                var slug = summary.key
-                var displayTags = summary.tags.join(", ")
-                projectListModel.append({
-                    key: slug,
-                    name: summary.name,
-                    icon: summary.icon,
-                    lastProfile: summary.defaultProfile,
-                    tags: displayTags,
-                    status: "Ready",
-                    favorite: false,
-                    active: false,
-                    usageHours: 0
-                })
-                window.projectDetails[slug] = summary
-                window.updateTagOptions()
-                stackView.pop()
+                if (projectModel.addProject(summary)) {
+                    window.updateTagOptions()
+                    stackView.pop()
+                } else {
+                    console.warn("Failed to add project", summary)
+                }
             }
         }
     }
@@ -412,13 +163,12 @@ ApplicationWindow {
         id: globalComponent
         GlobalDashboard {
             theme: theme
-            projectsModel: projectListModel
-            projectDetails: window.projectDetails
+            projectsModel: projectModel
             onBackRequested: stackView.pop()
             onOpenProject: function(projectKey) {
-                var details = window.projectDetails[projectKey]
-                if (!details)
-                    details = { name: "Unknown", components: [] }
+                var details = projectModel.getProject(projectKey)
+                if (!details || !details.key)
+                    details = { key: projectKey, name: "Unknown", components: [] }
                 stackView.push({ item: projectComponent, properties: { projectData: details } })
             }
         }

--- a/src/main.py
+++ b/src/main.py
@@ -1,14 +1,23 @@
 import sys
 import os
+
 from PySide6.QtGui import QGuiApplication
 from PySide6.QtQml import QQmlApplicationEngine
+
+from core.database import ProjectDatabase
+from gui import ProjectListModel
 
 if __name__ == "__main__":
     # Set the QtQuick Controls style
     os.environ["QT_QUICK_CONTROLS_STYLE"] = "Basic"
 
     app = QGuiApplication(sys.argv)
+
+    database = ProjectDatabase()
+    model = ProjectListModel(database)
+
     engine = QQmlApplicationEngine()
+    engine.rootContext().setContextProperty("projectModel", model)
 
     # Construct the absolute path to the main QML file
     qml_file = os.path.join(os.path.dirname(__file__), "gui", "qml", "main.qml")
@@ -20,6 +29,9 @@ if __name__ == "__main__":
     if not engine.rootObjects():
         print("Error: Could not load QML file.")
         sys.exit(-1)
+
+    # Close the database connection when the app exits
+    app.aboutToQuit.connect(database.close)
 
     # Execute the application's event loop
     sys.exit(app.exec())


### PR DESCRIPTION
## Summary
- add a ProjectListModel that exposes ProjectDatabase records to QML and supports refresh, get and add helpers
- wire the database-backed model into main.py and export it through the QQmlContext
- update the main, home and dashboard QML views to consume the Python model and rebuild tag filtering dynamically

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68cfbcc9a194832d9c3cd0199f5f28b5